### PR TITLE
FIX small improvements

### DIFF
--- a/tornado_swagger/swagger.py
+++ b/tornado_swagger/swagger.py
@@ -118,7 +118,7 @@ class DocParser(object):
     def _parse_property(self, **kwargs):
         arg = kwargs.get('arg', None)
         self.properties.setdefault(arg, {}).update({
-            'type': 'string'
+            'description': self._get_body(**kwargs)
         })
 
     def _parse_ptype(self, **kwargs):
@@ -140,7 +140,8 @@ class DocParser(object):
         body = self._get_body(**kwargs)
         self.responseMessages.append({
             'code': arg,
-            'message': body
+            'message': body,
+            'responseModel': self.responseClass
         })
 
     def _parse_notes(self, **kwargs):


### PR DESCRIPTION
A few minor tweaks to get this working with the Tubular code base:

1. Stop making a blanket assumption about the type of property being `string` when parsing properties from the docstring.

2. When parsing docstring properties, include the description field of the [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#definitionResource) extracted from the description of the [epydoc](http://epydoc.sourceforge.net/epytext.html) field.

3.  Include a `responseModel` field as described by the [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#524-parameter-object) when parsing parameter types.
