### PR TITLE
APP-6929 preserve order of params/properties

### DIFF
--- a/tornado_swagger/swagger.py
+++ b/tornado_swagger/swagger.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from collections import OrderedDict
 import inspect
 from functools import wraps
 import epydoc.markup
@@ -40,10 +41,10 @@ class DocParser(object):
     def __init__(self):
         self.notes = None
         self.summary = None
-        self.responseClasses = {}
+        self.responseClasses = OrderedDict()
         self.responseMessages = []
-        self.params = {}
-        self.properties = {}
+        self.params = OrderedDict()
+        self.properties = OrderedDict()
 
     def parse_docstring(self, text):
         if text is None:


### PR DESCRIPTION
Preserve the order of a models' properties and params when
parsing them.